### PR TITLE
[Fix #1] フォロー/フォロワーリストが取得できるようにした

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.application'
 
 apply plugin: 'kotlin-android'
-
 apply plugin: 'kotlin-android-extensions'
+apply plugin: 'kotlin-kapt'
 
 android {
     compileSdkVersion 26
@@ -27,10 +27,14 @@ dependencies {
     implementation"org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"
     implementation 'com.android.support:appcompat-v7:26.1.0'
     implementation 'com.android.support.constraint:constraint-layout:1.0.2'
-    testImplementation 'junit:junit:4.12'
+
+    implementation "com.google.dagger:dagger:$dagger_version"
+    annotationProcessor "com.google.dagger:dagger-compiler:$dagger_version"
+    kapt "com.google.dagger:dagger-compiler:$dagger_version"
 
     implementation 'io.reactivex.rxjava2:rxjava:2.1.8'
 
+    testImplementation 'junit:junit:4.12'
     androidTestImplementation 'com.android.support.test:runner:1.0.1'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.1'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -33,6 +33,7 @@ dependencies {
     kapt "com.google.dagger:dagger-compiler:$dagger_version"
 
     implementation 'io.reactivex.rxjava2:rxjava:2.1.8'
+    implementation 'io.reactivex.rxjava2:rxandroid:2.0.1'
 
     implementation "com.squareup.retrofit2:retrofit:$retrofit_version"
     implementation "com.squareup.retrofit2:converter-gson:$retrofit_version"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -34,6 +34,10 @@ dependencies {
 
     implementation 'io.reactivex.rxjava2:rxjava:2.1.8'
 
+    implementation "com.squareup.retrofit2:retrofit:$retrofit_version"
+    implementation "com.squareup.retrofit2:converter-gson:$retrofit_version"
+    implementation "com.squareup.retrofit2:adapter-rxjava2:$retrofit_version"
+
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'com.android.support.test:runner:1.0.1'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.1'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     package="example.com.githubfollowmanager">
 
     <application
+        android:name=".MainApplication"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="example.com.githubfollowmanager">
 
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <application
         android:name=".MainApplication"
         android:allowBackup="true"

--- a/app/src/main/java/example/com/githubfollowmanager/MainActivity.kt
+++ b/app/src/main/java/example/com/githubfollowmanager/MainActivity.kt
@@ -11,7 +11,7 @@ import javax.inject.Inject
 
 class MainActivity : AppCompatActivity() {
 
-    val TAG = "MainActivity"
+    private val TAG = this::class.java.simpleName
 
     @Inject lateinit var userRepository: UserRepository
 

--- a/app/src/main/java/example/com/githubfollowmanager/MainActivity.kt
+++ b/app/src/main/java/example/com/githubfollowmanager/MainActivity.kt
@@ -1,15 +1,34 @@
 package example.com.githubfollowmanager
 
-import android.support.v7.app.AppCompatActivity
 import android.os.Bundle
+import android.support.v7.app.AppCompatActivity
+import android.util.Log
+import example.com.githubfollowmanager.repositories.UserRepository
+import io.reactivex.android.schedulers.AndroidSchedulers
+import io.reactivex.schedulers.Schedulers
 import kotlinx.android.synthetic.main.activity_main.*
+import javax.inject.Inject
 
 class MainActivity : AppCompatActivity() {
+
+    val TAG = "MainActivity"
+
+    @Inject lateinit var userRepository: UserRepository
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
 
         helloTextView.text = "Hello Kotlin!!"
+
+        (application as MainApplication).getComponent()
+                .plus().inject(this)
+
+        userRepository.fetchFollowers("takuaraki")
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe({
+                    Log.d(TAG, it.toString())
+                })
     }
 }

--- a/app/src/main/java/example/com/githubfollowmanager/MainApplication.kt
+++ b/app/src/main/java/example/com/githubfollowmanager/MainApplication.kt
@@ -1,0 +1,22 @@
+package example.com.githubfollowmanager
+
+import android.app.Application
+import example.com.githubfollowmanager.di.AppComponent
+import example.com.githubfollowmanager.di.AppModule
+import example.com.githubfollowmanager.di.DaggerAppComponent
+
+/**
+ * アプリケーションの継承クラス
+ */
+class MainApplication : Application() {
+
+    override fun onCreate() {
+        super.onCreate()
+    }
+
+    fun getComponent(): AppComponent =
+            DaggerAppComponent.builder()
+                    .appModule(AppModule())
+                    .build()
+
+}

--- a/app/src/main/java/example/com/githubfollowmanager/MainApplication.kt
+++ b/app/src/main/java/example/com/githubfollowmanager/MainApplication.kt
@@ -10,13 +10,16 @@ import example.com.githubfollowmanager.di.DaggerAppComponent
  */
 class MainApplication : Application() {
 
+    private lateinit var appComponent: AppComponent
+    fun getComponent() = appComponent
+
     override fun onCreate() {
         super.onCreate()
-    }
 
-    fun getComponent(): AppComponent =
-            DaggerAppComponent.builder()
-                    .appModule(AppModule())
-                    .build()
+        appComponent =
+                DaggerAppComponent.builder()
+                        .appModule(AppModule())
+                        .build()
+    }
 
 }

--- a/app/src/main/java/example/com/githubfollowmanager/di/ActivityComponent.kt
+++ b/app/src/main/java/example/com/githubfollowmanager/di/ActivityComponent.kt
@@ -1,0 +1,14 @@
+package example.com.githubfollowmanager.di
+
+import dagger.Subcomponent
+import example.com.githubfollowmanager.MainActivity
+
+/**
+ * Component of Activity
+ */
+@Subcomponent
+interface ActivityComponent {
+
+    fun inject(activity: MainActivity)
+
+}

--- a/app/src/main/java/example/com/githubfollowmanager/di/AppComponent.kt
+++ b/app/src/main/java/example/com/githubfollowmanager/di/AppComponent.kt
@@ -1,0 +1,15 @@
+package example.com.githubfollowmanager.di
+
+import dagger.Component
+import javax.inject.Singleton
+
+/**
+ * Component of Application
+ */
+@Singleton
+@Component(modules = [(AppModule::class)])
+interface AppComponent {
+
+    fun plus(): ActivityComponent
+
+}

--- a/app/src/main/java/example/com/githubfollowmanager/di/AppModule.kt
+++ b/app/src/main/java/example/com/githubfollowmanager/di/AppModule.kt
@@ -1,0 +1,10 @@
+package example.com.githubfollowmanager.di
+
+import dagger.Module
+
+/**
+ * Application内で共通して使われるクラスのProviderを管理するクラス
+ */
+@Module
+class AppModule constructor() {
+}

--- a/app/src/main/java/example/com/githubfollowmanager/di/AppModule.kt
+++ b/app/src/main/java/example/com/githubfollowmanager/di/AppModule.kt
@@ -1,10 +1,32 @@
 package example.com.githubfollowmanager.di
 
 import dagger.Module
+import dagger.Provides
+import example.com.githubfollowmanager.repositories.clients.GithubClient
+import okhttp3.OkHttpClient
+import retrofit2.Retrofit
+import retrofit2.adapter.rxjava2.RxJava2CallAdapterFactory
+import retrofit2.converter.gson.GsonConverterFactory
+import javax.inject.Singleton
 
 /**
  * Application内で共通して使われるクラスのProviderを管理するクラス
  */
 @Module
 class AppModule constructor() {
+
+    @Singleton
+    @Provides
+    fun provideOkHttpClient() = OkHttpClient.Builder().build()
+
+    @Singleton
+    @Provides
+    fun provideGithubClient(okHttpClient: OkHttpClient) =
+            Retrofit.Builder().client(okHttpClient)
+                    .baseUrl("https://api.github.com")
+                    .addCallAdapterFactory(RxJava2CallAdapterFactory.create())
+                    .addConverterFactory(GsonConverterFactory.create())
+                    .build()
+                    .create(GithubClient::class.java)
+
 }

--- a/app/src/main/java/example/com/githubfollowmanager/repositories/UserRepository.kt
+++ b/app/src/main/java/example/com/githubfollowmanager/repositories/UserRepository.kt
@@ -1,0 +1,29 @@
+package example.com.githubfollowmanager.repositories
+
+import example.com.githubfollowmanager.repositories.clients.GithubClient
+import javax.inject.Inject
+
+/**
+ * Githubユーザーのデータを管理するクラス
+ */
+class UserRepository @Inject constructor(
+        private val githubClient: GithubClient
+) {
+
+    /**
+     * 指定されたユーザーがフォローしているユーザーのリストを取得する
+     *
+     * @param userName ユーザー名
+     * @return 指定されたユーザーがフォローしているユーザーのリスト
+     */
+    fun fetchFollowing(userName: String) = githubClient.getFollowing(userName)
+
+    /**
+     * 指定されたユーザーをフォローしているユーザーのリストを取得する
+     *
+     * @param userName ユーザー名
+     * @return 指定されたユーザーをフォローしているユーザーのリスト
+     */
+    fun fetchFollowers(userName: String) = githubClient.getFollowers(userName)
+
+}

--- a/app/src/main/java/example/com/githubfollowmanager/repositories/clients/GithubClient.kt
+++ b/app/src/main/java/example/com/githubfollowmanager/repositories/clients/GithubClient.kt
@@ -1,0 +1,31 @@
+package example.com.githubfollowmanager.repositories.clients
+
+import example.com.githubfollowmanager.entities.User
+import io.reactivex.Observable
+import retrofit2.http.GET
+import retrofit2.http.Path
+
+/**
+ * GithubAPIを呼び出すClient
+ */
+interface GithubClient {
+
+    /**
+     * 指定されたユーザーがフォローしているユーザーのリストを取得する
+     *
+     * @param userName ユーザー名
+     * @return 指定されたユーザーがフォローしているユーザーのリスト
+     */
+    @GET("/users/{userName}/following")
+    fun getFollowing(@Path("userName") userName: String): Observable<List<User>>
+
+    /**
+     * 指定されたユーザーをフォローしているユーザーのリストを取得する
+     *
+     * @param userName ユーザー名
+     * @return 指定されたユーザーをフォローしているユーザーのリスト
+     */
+    @GET("/users/{userName}/followers")
+    fun getFollowers(@Path("userName") userName: String): Observable<List<User>>
+
+}

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@
 
 buildscript {
     ext.kotlin_version = '1.2.10'
+    ext.dagger_version = '2.14.1'
     repositories {
         google()
         jcenter()

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,8 @@
 buildscript {
     ext.kotlin_version = '1.2.10'
     ext.dagger_version = '2.14.1'
+    ext.retrofit_version = '2.3.0'
+
     repositories {
         google()
         jcenter()


### PR DESCRIPTION
## Issue
#1 

## 概要
GithubAPIの
https://developer.github.com/v3/users/followers/
を呼び出して、フォロー/フォロワーリストが取得できるようにした。

## 技術的変更点
- Dagger2を導入
- Retrofit2を導入
  - GithubClientをInject可能にした
- UserRepository（モデル層のクラス。API呼び出しや、DB、SharedPrefの管理担当）を作成

## 動作確認
29fff67 で、takuarakiのフォロワーリストをログ表示させることに成功しました。